### PR TITLE
Обновил composer.json для создания config.yaml без lock файла

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "scripts": {
-        "post-install-cmd": [
+        "post-update-cmd": [
             "@php -r \"file_exists('config.yaml') || copy('config.example.yaml', 'config.yaml');\""
         ],
         "style-fix": "vendor/bin/php-cs-fixer fix",


### PR DESCRIPTION
Решение для Issue #28: Надо подобрать правильное правило, которое отработает после composer install независимо от наличия composer.lock

Согласно официальной документации: https://getcomposer.org/doc/articles/scripts.md (Command events)
- post-update-cmd: occurs after the update command has been executed, or after the install command has been executed without a lock file present.

Как раз то, что необходимо для решения задачи :)