### PR TITLE
Refactor #37, add Mockery tests

### DIFF
--- a/commands/Devs/DevsCommand.php
+++ b/commands/Devs/DevsCommand.php
@@ -43,7 +43,7 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
                 $topic = new TopicModel($args['topic']);
                 $content = $topic->getContent();
             } catch (TopicExceptionFileNotFound $e) {
-                // Exception with log level: log exception or notify admin with $e->getMessage()
+                // Exception with low log level: log exception or notify admin with $e->getMessage()
                 return $message->say('Команда не найдена.');
             } catch (TopicException $e) {
                 // Exception with high log level: log exception or notify admin with $e->getMessage()

--- a/commands/Devs/DevsCommand.php
+++ b/commands/Devs/DevsCommand.php
@@ -36,11 +36,11 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
         ]);
     }
 
-    public function run(\CharlotteDunois\Livia\CommandMessage $message, \ArrayObject $args, bool $fromPattern, TopicModel $external = null)
+    public function run(\CharlotteDunois\Livia\CommandMessage $message, \ArrayObject $args, bool $fromPattern)
     {
         if (!empty($args) && !empty($args['topic'])) {
             try {
-                $topic = ($external !== null) ? $external : new TopicModel($args['topic']);
+                $topic = new TopicModel($args['topic']);
                 $content = $topic->getContent();
             } catch (TopicExceptionFileNotFound $e) {
                 // Exception with log level: log exception or notify admin with $e->getMessage()

--- a/commands/Devs/Implementations/TopicModel.php
+++ b/commands/Devs/Implementations/TopicModel.php
@@ -26,6 +26,14 @@ class TopicModel
     }
 
     /**
+     * @return string
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
      * @param string $topic
      * @throws TopicException
      * @throws TopicExceptionFileNotFound
@@ -50,14 +58,6 @@ class TopicModel
         }
 
         return $content;
-    }
-
-    /**
-     * @return string
-     */
-    public function getContent(): string
-    {
-        return $this->content;
     }
 
     /**

--- a/commands/Devs/Implementations/TopicModel.php
+++ b/commands/Devs/Implementations/TopicModel.php
@@ -31,7 +31,7 @@ class TopicModel
      * @throws TopicExceptionFileNotFound
      * @return string
      */
-    public function load(string $topic): string
+    protected function load(string $topic): string
     {
         $file = $this->directory . $topic . $this->extension;
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",
+        "mockery/mockery": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.13"
     }
 }

--- a/tests/Commands/Devs/DevsCommandMockeryTest.php
+++ b/tests/Commands/Devs/DevsCommandMockeryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Commands;
+
+use ArrayObject;
+use Tests\TestCase;
+use React\Promise\Promise;
+use SoerBot\Commands\Devs\DevsCommand;
+
+class DevsCommandMockeryTest extends TestCase
+{
+    /** @var DevsCommand $command */
+    private $command;
+
+    private $client;
+
+    protected function setUp()
+    {
+        $commandCreate = require __DIR__ . '/../../../commands/Devs/devs.command.php';
+
+        $this->client = $this->createMock('\CharlotteDunois\Livia\LiviaClient');
+        $registry = $this->createMock('\CharlotteDunois\Livia\CommandRegistry');
+        $types = $this->createMock('\CharlotteDunois\Yasmin\Utils\Collection');
+
+        $types->expects($this->exactly(1))->method('has')->willReturn(true);
+        $registry->expects($this->exactly(2))->method('__get')->with('types')->willReturn($types);
+        $this->client->expects($this->exactly(2))->method('__get')->with('registry')->willReturn($registry);
+
+        $this->command = $commandCreate($this->client);
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testRunSayRightTextWhenTopicExist()
+    {
+        $input = 'first';
+        $expected = 'test file 1' . PHP_EOL;
+
+        $external = \Mockery::mock('overload:SoerBot\Commands\Devs\Implementations\TopicModel');
+        $external->shouldReceive('__construct')
+                ->once()
+                ->with($input);
+        $external->shouldReceive('getContent')
+                ->once()
+                ->andReturn($expected);
+
+        $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
+        $promise = new Promise(function () {
+        });
+        $commandMessage->expects($this->once())->method('direct')->with($expected)->willReturn($promise);
+
+        $this->command->run($commandMessage, new ArrayObject(['topic' => $input]), false, $external);
+    }
+
+    // this hack used when test is faild and PHPUnit makes serialization of object properties
+    public function __sleep()
+    {
+        $this->command = null;
+    }
+}

--- a/tests/Commands/Devs/DevsCommandMockeryTest.php
+++ b/tests/Commands/Devs/DevsCommandMockeryTest.php
@@ -46,9 +46,6 @@ class DevsCommandMockeryTest extends TestCase
         $expected = 'test file 1' . PHP_EOL;
 
         $external = \Mockery::mock('overload:SoerBot\Commands\Devs\Implementations\TopicModel');
-        $external->shouldReceive('__construct')
-                ->once()
-                ->with($input);
         $external->shouldReceive('getContent')
                 ->once()
                 ->andReturn($expected);

--- a/tests/Commands/Devs/DevsCommandTest.php
+++ b/tests/Commands/Devs/DevsCommandTest.php
@@ -76,18 +76,14 @@ class DevsCommandTest extends TestCase
     public function testRunSayDefaultText()
     {
         $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
-        $promise = new Promise(function () {
-        });
-        $commandMessage->expects($this->once())->method('say')->with($this->message)->willReturn($promise);
+        $commandMessage->expects($this->once())->method('say')->with($this->message);
         $this->command->run($commandMessage, new ArrayObject(['topic' => '']), false);
     }
 
     public function testRunSayDefaultTextWhenTopicNotExist(): void
     {
         $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
-        $promise = new Promise(function () {
-        });
-        $commandMessage->expects($this->once())->method('say')->with('Команда не найдена.')->willReturn($promise);
+        $commandMessage->expects($this->once())->method('say')->with('Команда не найдена.');
         $this->command->run($commandMessage, new ArrayObject(['topic' => 'not_exist']), false);
     }
 

--- a/tests/Commands/Devs/DevsCommandTest.php
+++ b/tests/Commands/Devs/DevsCommandTest.php
@@ -6,7 +6,6 @@ use ArrayObject;
 use Tests\TestCase;
 use React\Promise\Promise;
 use SoerBot\Commands\Devs\DevsCommand;
-use SoerBot\Commands\Devs\Implementations\TopicModel;
 
 class DevsCommandTest extends TestCase
 {
@@ -92,21 +91,13 @@ class DevsCommandTest extends TestCase
         $this->command->run($commandMessage, new ArrayObject(['topic' => 'not_exist']), false);
     }
 
-    public function testRunSayRightTextWhenTopicExist()
+    public function testRunSayDefaultTextWhenTopicExist()
     {
-        $input = 'first';
-        $path = __DIR__ . '/testfiles/';
-
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
-
         $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
         $promise = new Promise(function () {
         });
-        $commandMessage->expects($this->once())->method('direct')->with('test file 1' . PHP_EOL)->willReturn($promise);
-        $this->command->run($commandMessage, new ArrayObject(['topic' => $input]), false, $topic);
+        $commandMessage->expects($this->once())->method('direct')->with($this->isType('string'))->willReturn($promise);
+        $this->command->run($commandMessage, new ArrayObject(['topic' => 'list']), false);
     }
 
     // this hack used when test is faild and PHPUnit makes serialization of object properties

--- a/tests/Commands/Devs/TopicModelTest.php
+++ b/tests/Commands/Devs/TopicModelTest.php
@@ -9,9 +9,6 @@ use SoerBot\Commands\Devs\Exceptions\TopicExceptionFileNotFound;
 
 class TopicModelTest extends TestCase
 {
-    /** @var TopicModel $topic */
-    private $topic;
-
     protected function setUp()
     {
         parent::setUp();


### PR DESCRIPTION
Отрефакторил команду run, поправил косяк с моделью (метод load был публичным, а не должен был быть), добавил отдельным файлом  Mockery тесты. Несколько вопросов по ходу выполнения задания:
1. Просьба глянуть DevsCommandMockeryTest.php, правильно ли я улавливаю суть мок объектов, что это объекты с заранее определенным поведением (что позволяет нам тестировать классы, которые их используют на заведомо правильное поведение и известные возвращаемые данные), которые так же отслеживают у себя внутри заданное поведение (то есть выполнение заранее известных нам методов, включая количество дерганий и передаваемые в них данные). И есть ли необходимость проверять, что load был вызван в конструкторе, и если да, можешь подсказать как? Способа проверки того, что происходит в конструкторе не нашел.
        $external->shouldReceive('load') // такой код не работает
                ->with($input)
                ->once();
2. Вопрос по DevsCommandTest.php метод testRunSayDefaultTextWhenTopicExist там нет возможности передать внутрь тестовые данные. Мы обсуждали возможность тестирования на реальных объектах (классическое тестирование). Уточню, а правильно ли тестировать на реальных данных если другой возможности нет?
    
