### PR TITLE
Extend #56 with new functionality: fact by number. 

### DIFF
--- a/commands/PhpFact/Implementations/PhpFacts.php
+++ b/commands/PhpFact/Implementations/PhpFacts.php
@@ -28,6 +28,22 @@ class PhpFacts
     }
 
     /**
+     * @param int $position
+     *
+     * @return bool|string
+     */
+    public function get(int $position)
+    {
+        // position normalization for array indexes
+        --$position;
+        if ($this->hasPosition($position)) {
+            return $this->facts[$position];
+        }
+
+        return false;
+    }
+
+    /**
      * Returns random fact.
      *
      * @return string
@@ -36,7 +52,7 @@ class PhpFacts
     {
         $length = count($this->facts) - 1;
 
-        return $this->facts[random_int(0, $length)];
+        return $this->facts[rand(0, $length)];
     }
 
     /**
@@ -44,9 +60,23 @@ class PhpFacts
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->facts);
+    }
+
+    /**
+     * @param int $position
+     * @return bool
+     */
+    private function hasPosition(int $position): bool
+    {
+        $final = count($this->facts) - 1;
+        if ($position < 0 || $position > $final) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/commands/PhpFact/Implementations/PhpFacts.php
+++ b/commands/PhpFact/Implementations/PhpFacts.php
@@ -36,7 +36,7 @@ class PhpFacts
     {
         // position normalization for array indexes
         --$position;
-        if ($this->hasPosition($position)) {
+        if (array_key_exists($position, $this->facts)) {
             return $this->facts[$position];
         }
 
@@ -63,20 +63,6 @@ class PhpFacts
     public function count(): int
     {
         return count($this->facts);
-    }
-
-    /**
-     * @param int $position
-     * @return bool
-     */
-    private function hasPosition(int $position): bool
-    {
-        $final = count($this->facts) - 1;
-        if ($position < 0 || $position > $final) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/commands/PhpFact/PhpFactCommand.php
+++ b/commands/PhpFact/PhpFactCommand.php
@@ -14,7 +14,7 @@ class PhpFactCommand extends \CharlotteDunois\Livia\Commands\Command
     {
         parent::__construct($client, [
             'name' => 'phpfact', // Give command name
-            'aliases' => ['fact'],
+            'aliases' => ['php'],
             'group' => 'utils', // Group in ['command', 'util']
             'description' => 'Show PHP facts from https://github.com/pqr/5minphp-bot.', // Fill the description
             'guildOnly' => false,

--- a/commands/PhpFact/PhpFactCommand.php
+++ b/commands/PhpFact/PhpFactCommand.php
@@ -2,6 +2,7 @@
 
 namespace SoerBot\Commands\PhpFact;
 
+use CharlotteDunois\Livia\CommandMessage;
 use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
 use SoerBot\Commands\PhpFact\Exceptions\PhpFactException;
 use SoerBot\Commands\PhpFact\Exceptions\StorageException;
@@ -32,36 +33,9 @@ class PhpFactCommand extends \CharlotteDunois\Livia\Commands\Command
         ]);
     }
 
-    public function run(\CharlotteDunois\Livia\CommandMessage $message, \ArrayObject $args, bool $fromPattern)
+    public function run(CommandMessage $message, \ArrayObject $args, bool $fromPattern)
     {
-        try {
-            $storage = new FileStorage();
-            $fact = new PhpFacts($storage);
-        } catch (StorageException $e) {
-            // Exception on storage level: log exception or notify admin with $e->getMessage()
-            return $this->getErrorMessage($message);
-        } catch (PhpFactException $e) {
-            // Exception on class level: log exception or notify admin with $e->getMessage()
-            return $this->getErrorMessage($message);
-        } catch (\Throwable $e) {
-            // Exception with emergency level: log exception or notify admin with $e->getMessage()
-            return $this->getErrorMessage($message);
-        }
-
-        switch ($args['command']) {
-            case 'fact':
-                return $message->say($fact->getRandom());
-
-                break;
-            case 'stat':
-                return $message->say('We have ' . $fact->count() . ' facts in collection.');
-
-                break;
-            default:
-                return $message->say($this->getDefaultMessage());
-
-                break;
-        }
+        return $this->commandHandler($message, $args);
     }
 
     public function serialize()
@@ -69,13 +43,96 @@ class PhpFactCommand extends \CharlotteDunois\Livia\Commands\Command
         return [];
     }
 
-    protected function getDefaultMessage()
+    /**
+     * Parse args and return result.
+     *
+     * @param CommandMessage $message
+     * @param \ArrayObject $args
+     * @return \React\Promise\ExtendedPromiseInterface
+     */
+    protected function commandHandler(CommandMessage $message, \ArrayObject $args)
     {
-        return 'Input one of the command:' . PHP_EOL . 'fact - get random php fact' . PHP_EOL . 'stat - get php facts statistics';
+        try {
+            $facts = $this->initFacts();
+        } catch (StorageException $e) {
+            // Exception on storage level: log exception or notify admin with $e->getMessage()
+            return $message->say($this->getErrorMessage());
+        } catch (PhpFactException $e) {
+            // Exception on class level: log exception or notify admin with $e->getMessage()
+            return $message->say($this->getErrorMessage());
+        } catch (\Throwable $e) {
+            // Exception with emergency level: log exception or notify admin with $e->getMessage()
+            return $message->say($this->getErrorMessage());
+        }
+
+        $parsed = trim($args['command']);
+
+        if (empty($parsed)) {
+            return $message->say($this->getDefaultMessage());
+        }
+
+        if (preg_match('/([a-z]+)(?:\s+(\d+))?$/iSu', $args['command'], $match)) {
+            array_shift($match);
+
+            switch ($match[0]) {
+                case 'fact':
+                    if (!empty($match[1])) {
+                        $fact = $facts->get($match[1]) ? $facts->get($match[1]) : $this->getFactNotFoundMessage($match[1]);
+
+                        return $message->say($fact);
+                    }
+
+                    return $message->say($facts->getRandom());
+
+                    break;
+                case 'stat':
+                    return $message->say('We have ' . ($facts->count() > 1 ? $facts->count() . ' facts' : $facts->count() . ' fact') . ' in collection.');
+
+                    break;
+                case 'list':
+                    return $message->say($this->getDefaultMessage());
+
+                    break;
+                default:
+                    return $message->say($this->getCommandNotFoundMessage($args['command']));
+
+                    break;
+            }
+        }
+
+        return $message->say($this->getCommandNotFoundMessage($args['command']));
     }
 
-    protected function getErrorMessage(\CharlotteDunois\Livia\CommandMessage $message)
+    /**
+     * Initialize object.
+     *
+     * @throws \Exception|PhpFactException
+     * @return PhpFacts
+     */
+    protected function initFacts(): PhpFacts
     {
-        return $message->say('Something went wrong. Today without interesting PHP facts. Sorry!');
+        $storage = new FileStorage();
+
+        return new PhpFacts($storage);
+    }
+
+    protected function getDefaultMessage()
+    {
+        return 'Input one of the command:' . PHP_EOL . 'fact - get random php fact' . PHP_EOL . 'fact [num] - get php fact by number' . PHP_EOL . 'stat - get php facts statistics' . PHP_EOL . 'list - list all possible command';
+    }
+
+    protected function getErrorMessage()
+    {
+        return 'Something went wrong. Today without interesting PHP facts. Sorry!';
+    }
+
+    protected function getCommandNotFoundMessage(string $command)
+    {
+        return 'The ' . $command . ' is wrong command. Use $phpfact list for right command list.';
+    }
+
+    protected function getFactNotFoundMessage(string $position)
+    {
+        return 'The ' . $position . ' is wrong fact. Use $phpfact stat to find right position number.';
     }
 }

--- a/tests/Commands/PhpFact/PhpFactsTest.php
+++ b/tests/Commands/PhpFact/PhpFactsTest.php
@@ -33,33 +33,6 @@ class PhpFactsTest extends TestCase
      */
 
     /**
-     * @dataProvider providePositionCorners
-     */
-    public function testHasPositionReturnExpected($position, $expected)
-    {
-        $method = $this->getPrivateMethod($this->facts, 'hasPosition');
-
-        $this->assertSame($expected, $method->invokeArgs($this->facts, [$position]));
-    }
-
-    public function providePositionCorners()
-    {
-        $file = __DIR__ . '/phpfacts.txt';
-        $storage = new FileStorage($file);
-        $facts = new PhpFacts($storage);
-
-        $countFacts = count($this->getPrivateVariableValue($facts, 'facts'));
-
-        return [
-            'below minimum' => [-1, false],
-            'array start' => [0, true],
-            'array before stop' => [$countFacts - 2, true],
-            'array stop' => [$countFacts - 1, true],
-            'above maximum' => [$countFacts, false],
-        ];
-    }
-
-    /**
      * @dataProvider provideFactsContentCorners
      */
     public function testGetReturnExpected($position, $expected)


### PR DESCRIPTION
Добавил возможность находить факт по номеру. Прошу сделать код ревью и несколько вопросов:
- как считаешь, надо ли выделить всю проверку входящих аргументов (метод commandHandler в PhpFactCommand начиная с $parsed = trim($args['command']); и до конца) в отдельный метод. Потому что код просится на выделение в отдельный метод, но смущает то, что придется прокидывать очень много параметров. С другой стороны имея отдельный метод, мы сможем его оттестировать напрямую, а не через подлезание из run. 
- уточню по поводу комментариев, так как эта тема все время вызывает какой-то дикий холивар. В PhpFacts для нахождения факта в массиве я нормализую входящую позицию. В данном случае такой комментарий считаешь допустимым или это очевидный момент? С моей точки зрения он облегчает понимание того что происходит, без необходимости особо вникать что есть позиция.
        // position normalization for array indexes
        --$position;
- по возможности замечания по коду, допустимо ли например использовать if в case и что еще бросается в глаза :)