### PR TITLE
Extend #56 with Mockery tests

### DIFF
--- a/commands/PhpFact/Implementations/PhpFacts.php
+++ b/commands/PhpFact/Implementations/PhpFacts.php
@@ -23,7 +23,7 @@ class PhpFacts
         $this->facts = $this->load($storage);
 
         if (empty($this->facts)) {
-            throw new PhpFactException('Facts array was empty.');
+            throw new PhpFactException('Facts array is empty.');
         }
     }
 

--- a/commands/PhpFact/Implementations/PhpFacts.php
+++ b/commands/PhpFact/Implementations/PhpFacts.php
@@ -34,10 +34,9 @@ class PhpFacts
      */
     public function get(int $position)
     {
-        // position normalization for array indexes
-        --$position;
-        if (array_key_exists($position, $this->facts)) {
-            return $this->facts[$position];
+        $index = --$position;
+        if (array_key_exists($index, $this->facts)) {
+            return $this->facts[$index];
         }
 
         return false;

--- a/tests/Commands/PhpFact/PhpFactCommandMockeryTest.php
+++ b/tests/Commands/PhpFact/PhpFactCommandMockeryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Commands;
+
+use ArrayObject;
+use Tests\TestCase;
+use SoerBot\Commands\PhpFact\PhpFactCommand;
+use SoerBot\Commands\PhpFact\Exceptions\PhpFactException;
+use SoerBot\Commands\PhpFact\Exceptions\StorageException;
+
+class PhpFactCommandMockeryTest extends TestCase
+{
+    /** @var PhpFactCommand $command */
+    private $command;
+
+    private $client;
+
+    protected function setUp()
+    {
+        $commandCreate = require __DIR__ . '/../../../commands/PhpFact/phpfact.command.php';
+
+        $this->client = $this->createMock('\CharlotteDunois\Livia\LiviaClient');
+        $registry = $this->createMock('\CharlotteDunois\Livia\CommandRegistry');
+        $types = $this->createMock('\CharlotteDunois\Yasmin\Utils\Collection');
+
+        $types->expects($this->exactly(1))->method('has')->willReturn(true);
+        $registry->expects($this->exactly(2))->method('__get')->with('types')->willReturn($types);
+        $this->client->expects($this->exactly(2))->method('__get')->with('registry')->willReturn($registry);
+
+        $this->command = $commandCreate($this->client);
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testRunSayErrorTextWhenSomethingWentWrongInPhpFactsClass()
+    {
+        $input = 'fact';
+        $method = $this->getPrivateMethod($this->command, 'getErrorMessage');
+        $errorMessage = $method->invoke($this->command);
+
+        $external = \Mockery::mock('overload:SoerBot\Commands\PhpFact\Implementations\PhpFacts');
+        $external->shouldReceive('__construct')
+                ->once()
+                ->andThrow(new PhpFactException('Facts array is empty.'));
+
+        $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
+        $commandMessage->expects($this->once())->method('say')->with($errorMessage);
+
+        $this->command->run($commandMessage, new ArrayObject(['command' => $input]), false);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testRunSayErrorTextWhenSomethingWentWrongInFileStorageClass()
+    {
+        $input = 'fact';
+
+        $storage = \Mockery::mock('overload:SoerBot\Commands\PhpFact\Implementations\FileStorage');
+        $storage->shouldReceive('__construct')
+                ->once()
+                ->andThrow(new StorageException('Check source file.'));
+
+        $external = \Mockery::mock('overload:SoerBot\Commands\PhpFact\Implementations\PhpFacts');
+        $external->shouldNotReceive('__construct');
+
+        $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
+        $commandMessage->expects($this->once())->method('say')->with('Something went wrong. Today without interesting PHP facts. Sorry!');
+
+        $this->command->run($commandMessage, new ArrayObject(['command' => $input]), false);
+    }
+
+    // this hack used when test is faild and PHPUnit makes serialization of object properties
+    public function __sleep()
+    {
+        $this->command = null;
+    }
+}

--- a/tests/Commands/PhpFact/PhpFactCommandTest.php
+++ b/tests/Commands/PhpFact/PhpFactCommandTest.php
@@ -86,16 +86,16 @@ class PhpFactCommandTest extends TestCase
 
     public function testRunSayDefaultTextWhenCommandNotFound()
     {
+        $input = 'non_exist';
         $method = $this->getPrivateMethod($this->command, 'getCommandNotFoundMessage');
+        $notFoundMessage = $method->invokeArgs($this->command, [$input]);
 
         $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
         $commandMessage->expects($this->once())
             ->method('say')
-            ->with(
-                $method->invokeArgs($this->command, ['non_exist'])
-            );
+            ->with($notFoundMessage);
 
-        $this->command->run($commandMessage, new ArrayObject(['command' => 'non_exist']), false);
+        $this->command->run($commandMessage, new ArrayObject(['command' => $input]), false);
     }
 
     public function testRunSayOneOfFactWhenFactCommand()
@@ -126,7 +126,7 @@ class PhpFactCommandTest extends TestCase
         $this->command->run($commandMessage, new ArrayObject(['command' => 'fact']), false);
     }
 
-    public function testRunSayConcreteFactWhenFactCommandHasExistNumber()
+    public function testRunSayConcreteFactWhenFactCommandExistingNumber()
     {
         try {
             $storage = new FileStorage();
@@ -147,16 +147,15 @@ class PhpFactCommandTest extends TestCase
         $this->command->run($commandMessage, new ArrayObject(['command' => 'fact 2']), false);
     }
 
-    public function testRunSayConcreteFactWhenFactCommandHasNonExistNumber()
+    public function testRunSayConcreteFactWhenFactCommandNonExistNumber()
     {
         $method = $this->getPrivateMethod($this->command, 'getFactNotFoundMessage');
+        $factNotFoundMessage = $method->invokeArgs($this->command, ['100']);
 
         $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
         $commandMessage->expects($this->once())
             ->method('say')
-            ->with(
-                $method->invokeArgs($this->command, ['100'])
-            );
+            ->with($factNotFoundMessage);
 
         $this->command->run($commandMessage, new ArrayObject(['command' => 'fact 100']), false);
     }


### PR DESCRIPTION
Добавил два Mockery теста с пробросом объектов (overload) на проверку правильности поведения при выбросе исключений как из объекта с фактами PhpFacts, так и из объекта FileStorage, от которого PhpFacts получает данные. Так же улучшил читаемость тестов, переработал комментарий в код по прошлому ревью (https://github.com/soersoft/soerbot/pull/90).

Работу теперь веду мелкими шажками, одно исправление (группа связных исправлений), один коммит. Одно добавление (группа связных добавлений), один коммит. 

Единственная просьба, глянуть Mockery тесты, есть ли по ним замечания :)