### PR TITLE
Add experimental implementation of Configurator (#94)

### DIFF
--- a/commands/Devs/DevsCommand.php
+++ b/commands/Devs/DevsCommand.php
@@ -2,6 +2,7 @@
 
 namespace SoerBot\Commands\Devs;
 
+use SoerBot\Configurator;
 use SoerBot\Commands\Devs\Exceptions\TopicException;
 use SoerBot\Commands\Devs\Implementations\TopicModel;
 use SoerBot\Commands\Devs\Exceptions\TopicExceptionFileNotFound;
@@ -9,11 +10,18 @@ use SoerBot\Commands\Devs\Exceptions\TopicExceptionFileNotFound;
 class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
 {
     /**
+     * @var array
+     */
+    protected $settings = [];
+
+    /**
      * @param \CharlotteDunois\Livia\LiviaClient $client
      * @throws \Exception
      */
     public function __construct(\CharlotteDunois\Livia\LiviaClient $client)
     {
+        $this->settings = Configurator::get('commands');
+
         parent::__construct($client, [
             'name' => 'devs', // Give command name
             'aliases' => ['dev'],
@@ -40,7 +48,9 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
     {
         if (!empty($args) && !empty($args['topic'])) {
             try {
-                $topic = new TopicModel($args['topic']);
+                $path = __DIR__ . $this->settings['store'];
+
+                $topic = new TopicModel($args['topic'], $path);
                 $content = $topic->getContent();
             } catch (TopicExceptionFileNotFound $e) {
                 // Exception with low log level: log exception or notify admin with $e->getMessage()

--- a/commands/Devs/Implementations/TopicModel.php
+++ b/commands/Devs/Implementations/TopicModel.php
@@ -18,11 +18,13 @@ class TopicModel
     /**
      * TopicModel constructor.
      * @param string $topic
+     * @param string $directory
      * @throws TopicException
+     * @throws TopicExceptionFileNotFound
      */
-    public function __construct(string $topic)
+    public function __construct(string $topic, string $directory = '')
     {
-        $this->content = $this->load($topic);
+        $this->content = $this->load($topic, $directory);
     }
 
     /**
@@ -35,12 +37,21 @@ class TopicModel
 
     /**
      * @param string $topic
+     * @param string $directory
      * @throws TopicException
      * @throws TopicExceptionFileNotFound
      * @return string
      */
-    protected function load(string $topic): string
+    protected function load(string $topic, string $directory): string
     {
+        if (!empty($directory)) {
+            if (!is_dir($directory)) {
+                throw new TopicExceptionFileNotFound('Directory ' . $directory . ' does not exists. Check directory source.');
+            }
+
+            $this->directory = $directory;
+        }
+
         $file = $this->directory . $topic . $this->extension;
 
         if (!file_exists($file)) {

--- a/tests/Commands/Devs/DevsCommandTest.php
+++ b/tests/Commands/Devs/DevsCommandTest.php
@@ -73,6 +73,14 @@ class DevsCommandTest extends TestCase
         $this->assertEquals($this->command->args[0]['type'], 'string');
     }
 
+    public function testConstructorSetGlobalSettings()
+    {
+        $settings = $this->getPrivateVariableValue($this->command, 'settings');
+
+        $this->assertNotEmpty($settings);
+        $this->assertArrayHasKey('store', $settings);
+    }
+
     public function testRunSayDefaultText()
     {
         $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');

--- a/tests/Commands/Devs/TopicModelTest.php
+++ b/tests/Commands/Devs/TopicModelTest.php
@@ -17,6 +17,17 @@ class TopicModelTest extends TestCase
     /**
      * Exceptions.
      */
+    public function testConstructorThrowExceptionWhenDirectoryNotExist()
+    {
+        $input = 'second';
+        $path = __DIR__ . '/not_exist/';
+
+        $this->expectException(TopicExceptionFileNotFound::class);
+        $this->expectExceptionMessage('Directory ' . $path . ' does not exists. Check directory source.');
+
+        new TopicModel($input, $path);
+    }
+
     public function testConstructorThrowExceptionWhenFileNotExist()
     {
         $input = 'not_exist';
@@ -27,10 +38,7 @@ class TopicModelTest extends TestCase
         $this->expectException(TopicExceptionFileNotFound::class);
         $this->expectExceptionMessage('File ' . $file . ' does not exists. Check file source.');
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        new TopicModel($input, $path);
     }
 
     public function testConstructorThrowExceptionWhenFileIsEmpty()
@@ -43,10 +51,7 @@ class TopicModelTest extends TestCase
         $this->expectException(TopicException::class);
         $this->expectExceptionMessage('File ' . $file . ' is empty. Check file source.');
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        new TopicModel($input, $path);
     }
 
     /**
@@ -61,10 +66,7 @@ class TopicModelTest extends TestCase
         $input = 'second';
         $path = __DIR__ . '/testfiles/';
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        $topic = new TopicModel($input, $path);
 
         $this->assertSame('test file 2', $topic->getContent());
     }
@@ -74,10 +76,8 @@ class TopicModelTest extends TestCase
         $input = 'second';
         $path = __DIR__ . '/testfiles/';
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        $topic = new TopicModel($input, $path);
+
         $method = $this->getPrivateMethod($topic, 'isTopic');
 
         $this->assertTrue($method->invokeArgs($topic, [__DIR__ . '/testfiles/second.topic.md']));
@@ -88,10 +88,7 @@ class TopicModelTest extends TestCase
         $input = 'second';
         $path = __DIR__ . '/testfiles/';
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        $topic = new TopicModel($input, $path);
         $method = $this->getPrivateMethod($topic, 'isTopic');
 
         $this->assertFalse($method->invokeArgs($topic, [__DIR__ . '/testfiles/wrong_extension.md']));


### PR DESCRIPTION
Пример реализации использования глобального Configurator (#94) в команде. Для корректной работы надо в config.yaml прописать секцию, откуда берутся настройки:
```
# Commands settings
commands:
  store: '/store/'      # Default storage directory value
```