### PR TITLE
 Add experimental implementation of Settings #94

### DIFF
--- a/commands/Devs/DevsCommand.php
+++ b/commands/Devs/DevsCommand.php
@@ -2,6 +2,7 @@
 
 namespace SoerBot\Commands\Devs;
 
+use SoerBot\Configurator;
 use SoerBot\Commands\Devs\Exceptions\TopicException;
 use SoerBot\Commands\Devs\Implementations\TopicModel;
 use SoerBot\Commands\Devs\Exceptions\TopicExceptionFileNotFound;
@@ -9,11 +10,18 @@ use SoerBot\Commands\Devs\Exceptions\TopicExceptionFileNotFound;
 class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
 {
     /**
+     * @var array
+     */
+    protected $settings = [];
+
+    /**
      * @param \CharlotteDunois\Livia\LiviaClient $client
      * @throws \Exception
      */
     public function __construct(\CharlotteDunois\Livia\LiviaClient $client)
     {
+        $this->settings = Configurator::get('commands');
+
         parent::__construct($client, [
             'name' => 'devs', // Give command name
             'aliases' => ['dev'],
@@ -40,7 +48,9 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
     {
         if (!empty($args) && !empty($args['topic'])) {
             try {
-                $topic = new TopicModel($args['topic']);
+                $path = __DIR__ . $this->settings['store'];
+
+                $topic = new TopicModel($args['topic'], $path);
                 $content = $topic->getContent();
             } catch (TopicExceptionFileNotFound $e) {
                 // Exception with low log level: log exception or notify admin with $e->getMessage()

--- a/commands/Devs/DevsCommand.php
+++ b/commands/Devs/DevsCommand.php
@@ -41,7 +41,7 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
             ],
         ]);
 
-        $settings = Settings::init($this, __DIR__);
+        $this->settings = Settings::getInstance()->init($this, __DIR__);
     }
 
     public function run(\CharlotteDunois\Livia\CommandMessage $message, \ArrayObject $args, bool $fromPattern)
@@ -61,6 +61,10 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
             } catch (\Throwable $e) {
                 // Exception with high log level: log exception or notify admin with $e->getMessage()
                 return $message->say('Бот временно не работает. Мы уже занимаемся этой проблемой.');
+            }
+
+            if (array_key_exists('expected', $this->settings['devs'])) {
+                $content = $this->settings['devs']['expected'];
             }
 
             return $message->direct($content, ['split' => true])->then(function ($msg) use ($message, $args) {

--- a/commands/Devs/DevsCommand.php
+++ b/commands/Devs/DevsCommand.php
@@ -20,8 +20,6 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
      */
     public function __construct(\CharlotteDunois\Livia\LiviaClient $client)
     {
-        $this->settings = Settings::getInstance()->all();
-
         parent::__construct($client, [
             'name' => 'devs', // Give command name
             'aliases' => ['dev'],
@@ -42,6 +40,8 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
                 ],
             ],
         ]);
+
+        $settings = Settings::init($this, __DIR__);
     }
 
     public function run(\CharlotteDunois\Livia\CommandMessage $message, \ArrayObject $args, bool $fromPattern)

--- a/commands/Devs/DevsCommand.php
+++ b/commands/Devs/DevsCommand.php
@@ -2,7 +2,7 @@
 
 namespace SoerBot\Commands\Devs;
 
-use SoerBot\Configurator;
+use SoerBot\Settings;
 use SoerBot\Commands\Devs\Exceptions\TopicException;
 use SoerBot\Commands\Devs\Implementations\TopicModel;
 use SoerBot\Commands\Devs\Exceptions\TopicExceptionFileNotFound;
@@ -20,7 +20,7 @@ class DevsCommand extends \CharlotteDunois\Livia\Commands\Command
      */
     public function __construct(\CharlotteDunois\Livia\LiviaClient $client)
     {
-        $this->settings = Configurator::get('commands');
+        $this->settings = Settings::getInstance()->all();
 
         parent::__construct($client, [
             'name' => 'devs', // Give command name

--- a/commands/Devs/Implementations/TopicModel.php
+++ b/commands/Devs/Implementations/TopicModel.php
@@ -18,11 +18,13 @@ class TopicModel
     /**
      * TopicModel constructor.
      * @param string $topic
+     * @param string $directory
      * @throws TopicException
+     * @throws TopicExceptionFileNotFound
      */
-    public function __construct(string $topic)
+    public function __construct(string $topic, string $directory = '')
     {
-        $this->content = $this->load($topic);
+        $this->content = $this->load($topic, $directory);
     }
 
     /**
@@ -35,12 +37,21 @@ class TopicModel
 
     /**
      * @param string $topic
+     * @param string $directory
      * @throws TopicException
      * @throws TopicExceptionFileNotFound
      * @return string
      */
-    protected function load(string $topic): string
+    protected function load(string $topic, string $directory): string
     {
+        if (!empty($directory)) {
+            if (!is_dir($directory)) {
+                throw new TopicExceptionFileNotFound('Directory ' . $directory . ' does not exists. Check directory source.');
+            }
+
+            $this->directory = $directory;
+        }
+
         $file = $this->directory . $topic . $this->extension;
 
         if (!file_exists($file)) {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -59,6 +59,7 @@ class Runner
 
     /**
      * @return void
+     * @throws Exceptions\ConfigurationFileNotFound
      */
     public function settings(): void
     {
@@ -78,6 +79,8 @@ class Runner
         // Register our commands (this is an example path)
         // TODO вынести регистрацию команд из файла в структуру.
         $this->client->registry->registerCommand(...$this->loadCommands());
+
+        Settings::getInstance();
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SoerBot;
+
+class Settings
+{
+    /**
+     * @var Settings
+     */
+    private static $instance = null;
+
+    /**
+     * @var array
+     */
+    private $settings = [];
+
+    /**
+     * Get instance method.
+     *
+     * @return Settings
+     * @throws Exceptions\ConfigurationFileNotFound
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Get setting by key
+     *
+     * @param $key
+     * @param null $default
+     * @return mixed|null
+     */
+    public function get($key, $default = null)
+    {
+        return array_key_exists($key, $this->settings) ? $this->settings[$key] : $default;
+    }
+
+    /**
+     * Get all settings
+     *
+     * @return array
+     */
+    public function all(): array
+    {
+        return $this->settings;
+    }
+
+    /**
+     * Settings constructor.
+     * @throws Exceptions\ConfigurationFileNotFound
+     */
+    private function __construct()
+    {
+        $this->settings = Configurator::get('commands');
+    }
+
+    /**
+     * Magic __clone method
+     */
+    private function __clone()
+    {
+    }
+}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -2,6 +2,8 @@
 
 namespace SoerBot;
 
+use Symfony\Component\Yaml\Yaml;
+
 class Settings
 {
     /**
@@ -17,8 +19,8 @@ class Settings
     /**
      * Get instance method.
      *
-     * @return Settings
      * @throws Exceptions\ConfigurationFileNotFound
+     * @return Settings
      */
     public static function getInstance(): self
     {
@@ -29,8 +31,26 @@ class Settings
         return self::$instance;
     }
 
+    public function init(\CharlotteDunois\Livia\Commands\Command $command, $dir = __DIR__): array
+    {
+        $namespace = $command->__get('name');
+
+        $this->settings[$namespace] = [
+            'name' => $command->__get('name'),
+            'description' => $command->__get('description'),
+            'path' => $dir,
+        ];
+
+        if (is_dir($dir . '/config/') && file_exists($dir . '/config/config.yaml')) {
+            $localConfig = Yaml::parseFile($dir . '/config/config.yaml');
+            $this->settings[$namespace] = array_merge($this->settings[$namespace], $localConfig);
+        }
+
+        return $this->settings;
+    }
+
     /**
-     * Get setting by key
+     * Get setting by key.
      *
      * @param $key
      * @param null $default
@@ -42,7 +62,7 @@ class Settings
     }
 
     /**
-     * Get all settings
+     * Get all settings.
      *
      * @return array
      */
@@ -61,7 +81,7 @@ class Settings
     }
 
     /**
-     * Magic __clone method
+     * Magic __clone method.
      */
     private function __clone()
     {

--- a/tests/Commands/Devs/DevsCommandTest.php
+++ b/tests/Commands/Devs/DevsCommandTest.php
@@ -73,6 +73,14 @@ class DevsCommandTest extends TestCase
         $this->assertEquals($this->command->args[0]['type'], 'string');
     }
 
+    public function testConstructorSetGlobalSettings()
+    {
+        $settings = $this->getPrivateVariableValue($this->command, 'settings');
+
+        $this->assertNotEmpty($settings);
+        $this->assertArrayHasKey('store', $settings);
+    }
+
     public function testRunSayDefaultText()
     {
         $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');

--- a/tests/Commands/Devs/TopicModelTest.php
+++ b/tests/Commands/Devs/TopicModelTest.php
@@ -17,6 +17,17 @@ class TopicModelTest extends TestCase
     /**
      * Exceptions.
      */
+    public function testConstructorThrowExceptionWhenDirectoryNotExist()
+    {
+        $input = 'second';
+        $path = __DIR__ . '/not_exist/';
+
+        $this->expectException(TopicExceptionFileNotFound::class);
+        $this->expectExceptionMessage('Directory ' . $path . ' does not exists. Check directory source.');
+
+        new TopicModel($input, $path);
+    }
+
     public function testConstructorThrowExceptionWhenFileNotExist()
     {
         $input = 'not_exist';
@@ -27,10 +38,7 @@ class TopicModelTest extends TestCase
         $this->expectException(TopicExceptionFileNotFound::class);
         $this->expectExceptionMessage('File ' . $file . ' does not exists. Check file source.');
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        new TopicModel($input, $path);
     }
 
     public function testConstructorThrowExceptionWhenFileIsEmpty()
@@ -43,10 +51,7 @@ class TopicModelTest extends TestCase
         $this->expectException(TopicException::class);
         $this->expectExceptionMessage('File ' . $file . ' is empty. Check file source.');
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        new TopicModel($input, $path);
     }
 
     /**
@@ -61,10 +66,7 @@ class TopicModelTest extends TestCase
         $input = 'second';
         $path = __DIR__ . '/testfiles/';
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        $topic = new TopicModel($input, $path);
 
         $this->assertSame('test file 2', $topic->getContent());
     }
@@ -74,10 +76,8 @@ class TopicModelTest extends TestCase
         $input = 'second';
         $path = __DIR__ . '/testfiles/';
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        $topic = new TopicModel($input, $path);
+
         $method = $this->getPrivateMethod($topic, 'isTopic');
 
         $this->assertTrue($method->invokeArgs($topic, [__DIR__ . '/testfiles/second.topic.md']));
@@ -88,10 +88,7 @@ class TopicModelTest extends TestCase
         $input = 'second';
         $path = __DIR__ . '/testfiles/';
 
-        $reflection = new \ReflectionClass(TopicModel::class);
-        $topic = $reflection->newInstanceWithoutConstructor();
-        $this->setPrivateVariableValue($topic, 'directory', $path);
-        $topic->__construct($input);
+        $topic = new TopicModel($input, $path);
         $method = $this->getPrivateMethod($topic, 'isTopic');
 
         $this->assertFalse($method->invokeArgs($topic, [__DIR__ . '/testfiles/wrong_extension.md']));

--- a/tests/SettingTest.php
+++ b/tests/SettingTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests;
 
-use PHPUnit\Framework\TestCase;
 use SoerBot\Settings;
+use PHPUnit\Framework\TestCase;
 
 class SettingTest extends TestCase
 {
     /**
      * Exceptions.
      */
-    
+
     /**
      * Corner cases.
      */
@@ -32,6 +32,46 @@ class SettingTest extends TestCase
         $instance2 = Settings::getInstance();
 
         $this->assertSame($instance1, $instance2);
+    }
+
+    public function testInitSetCommandNamespace()
+    {
+        $map = [
+            ['name', 'devs'],
+            ['description', 'some description'],
+        ];
+        $command = $this->createMock('\CharlotteDunois\Livia\Commands\Command');
+        $command->method('__get')->will($this->returnValueMap($map));
+
+        $settings = Settings::getInstance()->init($command, __DIR__ . '/Commands/Devs');
+        $this->assertArrayHasKey('devs', $settings);
+    }
+
+    public function testInitSetCommandAttribute()
+    {
+        $map = [
+            ['name', 'devs'],
+            ['description', 'some description'],
+        ];
+        $command = $this->createMock('\CharlotteDunois\Livia\Commands\Command');
+        $command->method('__get')->will($this->returnValueMap($map));
+
+        $settings = Settings::getInstance()->init($command, __DIR__ . '/Commands/Devs');
+        $this->assertContains('some description', $settings['devs']);
+    }
+
+    public function testInitSetCommandAddParametersFromFile()
+    {
+        $map = [
+            ['name', 'devs'],
+            ['description', 'some description'],
+        ];
+        $command = $this->createMock('\CharlotteDunois\Livia\Commands\Command');
+        $command->method('__get')->will($this->returnValueMap($map));
+
+        $settings = Settings::getInstance()->init($command, __DIR__ . '/Commands/Devs');
+        $this->assertArrayHasKey('expected', $settings['devs']);
+        $this->assertEquals('value', $settings['devs']['expected']);
     }
 
     public function testGetReturnExpectedWhenExistKey()

--- a/tests/SettingTest.php
+++ b/tests/SettingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SoerBot\Settings;
+
+class SettingTest extends TestCase
+{
+    /**
+     * Exceptions.
+     */
+    
+    /**
+     * Corner cases.
+     */
+
+    /**
+     * Functionality.
+     */
+    public function testConstructorIsNotAccessible()
+    {
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessageRegExp('/^Call to private.*/');
+
+        new Settings();
+    }
+
+    public function testGetInstanceReturnSameInstance()
+    {
+        $instance1 = Settings::getInstance();
+        $instance2 = Settings::getInstance();
+
+        $this->assertSame($instance1, $instance2);
+    }
+
+    public function testGetReturnExpectedWhenExistKey()
+    {
+        $expected = '/store/';
+
+        $this->assertEquals($expected, Settings::getInstance()->get('store'));
+    }
+
+    public function testGetReturnNullWhenNotExistKey()
+    {
+        $this->assertNull(Settings::getInstance()->get('not_exist'));
+    }
+
+    public function testAllReturnExpectedType()
+    {
+        $settings = Settings::getInstance()->all();
+
+        $this->assertIsArray($settings);
+        $this->assertNotEmpty($settings);
+    }
+}


### PR DESCRIPTION
Пример реализации использования Settings через паттерн Singleton (#94) в команде. Для корректной работы надо в config.yaml прописать секцию, откуда берутся настройки:
```
# Commands settings
commands:
  store: '/store/'      # Default storage directory value
```

Разница, что глобальные настройки берутся только один раз и они становятся больше не доступны для команд. То есть мы показываем командам только то, что хотим показывать.