### PR TITLE
Update of PhpFacts PR #56

### DIFF
--- a/commands/PhpFact/Abstractions/AbstractCommandWithArguments.php
+++ b/commands/PhpFact/Abstractions/AbstractCommandWithArguments.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SoerBot\Commands\PhpFact\Abstractions;
+
+use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
+
+abstract class AbstractCommandWithArguments implements CommandInterface
+{
+    /**
+     * @var PhpFacts
+     */
+    protected $facts;
+
+    /**
+     * @var array
+     */
+    protected $args = [];
+
+    /**
+     * Command constructor.
+     *
+     * @param PhpFacts $facts
+     * @param array $args
+     */
+    public function __construct(PhpFacts $facts, array $args)
+    {
+        $this->facts = $facts;
+        $this->args = $args;
+    }
+}

--- a/commands/PhpFact/Abstractions/AbstractCommandWithoutArguments.php
+++ b/commands/PhpFact/Abstractions/AbstractCommandWithoutArguments.php
@@ -4,7 +4,7 @@ namespace SoerBot\Commands\PhpFact\Abstractions;
 
 use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
 
-abstract class AbstractCommand
+abstract class AbstractCommandWithoutArguments implements CommandInterface
 {
     /**
      * @var PhpFacts
@@ -15,17 +15,9 @@ abstract class AbstractCommand
      * Command constructor.
      *
      * @param PhpFacts $facts
-     * @param array $args
      */
-    public function __construct(PhpFacts $facts, array $args = [])
+    public function __construct(PhpFacts $facts)
     {
         $this->facts = $facts;
     }
-
-    /**
-     * Returns command result.
-     *
-     * @return string
-     */
-    abstract public function response(): string;
 }

--- a/commands/PhpFact/Abstractions/CommandInterface.php
+++ b/commands/PhpFact/Abstractions/CommandInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SoerBot\Commands\PhpFact\Abstractions;
+
+interface CommandInterface
+{
+    /**
+     * Returns command result.
+     *
+     * @return string
+     */
+    public function response(): string;
+}

--- a/commands/PhpFact/Implementations/CommandFactory.php
+++ b/commands/PhpFact/Implementations/CommandFactory.php
@@ -2,7 +2,7 @@
 
 namespace SoerBot\Commands\PhpFact\Implementations;
 
-use SoerBot\Commands\PhpFact\Abstractions\AbstractCommand;
+use SoerBot\Commands\PhpFact\Abstractions\CommandInterface;
 use SoerBot\Commands\PhpFact\Exceptions\CommandNotFoundException;
 use SoerBot\Commands\PhpFact\Implementations\Commands\FactCommand;
 use SoerBot\Commands\PhpFact\Implementations\Commands\ListCommand;
@@ -17,9 +17,9 @@ class CommandFactory
      * @param PhpFacts $facts
      * @param string $input
      * @throws CommandNotFoundException|CommandWrongUsageException
-     * @return AbstractCommand
+     * @return CommandInterface
      */
-    public static function build(PhpFacts $facts, string $input): AbstractCommand
+    public static function build(PhpFacts $facts, string $input): CommandInterface
     {
         if (preg_match('/^(?<command>[a-z]+)(?:\s+(?<position>\d+))?$/iSu', $input, $match)) {
             array_shift($match);

--- a/commands/PhpFact/Implementations/CommandFactory.php
+++ b/commands/PhpFact/Implementations/CommandFactory.php
@@ -8,6 +8,7 @@ use SoerBot\Commands\PhpFact\Implementations\Commands\FactCommand;
 use SoerBot\Commands\PhpFact\Implementations\Commands\ListCommand;
 use SoerBot\Commands\PhpFact\Implementations\Commands\StatCommand;
 use SoerBot\Commands\PhpFact\Exceptions\CommandWrongUsageException;
+use SoerBot\Commands\PhpFact\Implementations\Commands\SearchCommand;
 
 class CommandFactory
 {
@@ -26,6 +27,10 @@ class CommandFactory
 
             if ('fact' === $match['command']) {
                 return new FactCommand($facts, $match);
+            }
+
+            if ('search' === $match['command']) {
+                return new SearchCommand($facts, $match);
             }
 
             if ('stat' === $match['command']) {

--- a/commands/PhpFact/Implementations/CommandFactory.php
+++ b/commands/PhpFact/Implementations/CommandFactory.php
@@ -21,7 +21,7 @@ class CommandFactory
      */
     public static function build(PhpFacts $facts, string $input): CommandInterface
     {
-        if (preg_match('/^(?<command>[a-z]+)(?:\s+(?<position>\d+))?$/iSu', $input, $match)) {
+        if (preg_match('/^(?<command>[a-z]+)(?:\s+(?<argument>.*))?$/iSu', $input, $match)) {
             array_shift($match);
 
             if ('fact' === $match['command']) {

--- a/commands/PhpFact/Implementations/Commands/FactCommand.php
+++ b/commands/PhpFact/Implementations/Commands/FactCommand.php
@@ -53,16 +53,16 @@ class FactCommand extends AbstractCommandWithArguments
      */
     protected function initPosition(): void
     {
-        if (!isset($this->args['position'])) {
+        if (!isset($this->args['argument'])) {
             $this->position = null;
 
             return;
         }
 
-        if (!is_numeric($this->args['position'])) {
-            throw new CommandWrongUsageException('Wrong usage of fact [num] command. Check if ' . $this->args['position'] . ' is correct argument.');
+        if (!is_numeric($this->args['argument'])) {
+            throw new CommandWrongUsageException('Wrong usage of fact [num] command. Check if ' . $this->args['argument'] . ' is correct argument.');
         }
 
-        $this->position = (int)$this->args['position'];
+        $this->position = (int)$this->args['argument'];
     }
 }

--- a/commands/PhpFact/Implementations/Commands/FactCommand.php
+++ b/commands/PhpFact/Implementations/Commands/FactCommand.php
@@ -2,11 +2,11 @@
 
 namespace SoerBot\Commands\PhpFact\Implementations\Commands;
 
+use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithArguments;
 use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
-use SoerBot\Commands\PhpFact\Abstractions\AbstractCommand;
 use SoerBot\Commands\PhpFact\Exceptions\CommandWrongUsageException;
 
-class FactCommand extends AbstractCommand
+class FactCommand extends AbstractCommandWithArguments
 {
     /**
      * @var int

--- a/commands/PhpFact/Implementations/Commands/FactCommand.php
+++ b/commands/PhpFact/Implementations/Commands/FactCommand.php
@@ -2,14 +2,14 @@
 
 namespace SoerBot\Commands\PhpFact\Implementations\Commands;
 
-use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithArguments;
 use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
 use SoerBot\Commands\PhpFact\Exceptions\CommandWrongUsageException;
+use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithArguments;
 
 class FactCommand extends AbstractCommandWithArguments
 {
     /**
-     * @var int
+     * @var int|null
      */
     private $position;
 
@@ -20,11 +20,11 @@ class FactCommand extends AbstractCommandWithArguments
      * @param array $args
      * @throws CommandWrongUsageException
      */
-    public function __construct(PhpFacts $facts, array $args = [])
+    public function __construct(PhpFacts $facts, array $args)
     {
-        $this->position = $this->validPosition($args);
-
         parent::__construct($facts, $args);
+
+        $this->initPosition();
     }
 
     /**
@@ -48,20 +48,21 @@ class FactCommand extends AbstractCommandWithArguments
     /**
      * Checks if position is valid.
      *
-     * @param array $args
      * @throws CommandWrongUsageException
-     * @return int|null
+     * @return void
      */
-    protected function validPosition(array $args): ?int
+    protected function initPosition(): void
     {
-        if (!isset($args['position'])) {
-            return null;
+        if (!isset($this->args['position'])) {
+            $this->position = null;
+
+            return;
         }
 
-        if (!is_numeric($args['position'])) {
-            throw new CommandWrongUsageException('Wrong usage of fact [num] command. Check if ' . $args['position'] . ' is correct argument.');
+        if (!is_numeric($this->args['position'])) {
+            throw new CommandWrongUsageException('Wrong usage of fact [num] command. Check if ' . $this->args['position'] . ' is correct argument.');
         }
 
-        return (int)$args['position'];
+        $this->position = (int)$this->args['position'];
     }
 }

--- a/commands/PhpFact/Implementations/Commands/FactCommand.php
+++ b/commands/PhpFact/Implementations/Commands/FactCommand.php
@@ -60,7 +60,7 @@ class FactCommand extends AbstractCommandWithArguments
         }
 
         if (!is_numeric($this->args['argument'])) {
-            throw new CommandWrongUsageException('Wrong usage of fact [num] command. Check if ' . $this->args['argument'] . ' is correct argument.');
+            throw new CommandWrongUsageException('Wrong usage of fact command. Check if ' . $this->args['argument'] . ' is correct argument.');
         }
 
         $this->position = (int)$this->args['argument'];

--- a/commands/PhpFact/Implementations/Commands/ListCommand.php
+++ b/commands/PhpFact/Implementations/Commands/ListCommand.php
@@ -13,6 +13,11 @@ class ListCommand extends AbstractCommandWithoutArguments
      */
     public function response(): string
     {
-        return 'Input one of the command:' . PHP_EOL . 'fact - get random php fact' . PHP_EOL . 'fact [num] - get php fact by number' . PHP_EOL . 'stat - get php facts statistics' . PHP_EOL . 'list - list all possible command';
+        return  'Input one of the command:' . PHP_EOL .
+                'fact - get random php fact' . PHP_EOL .
+                'fact [num] - get php fact by number' . PHP_EOL .
+                'fact [word|text] - find php fact by text' . PHP_EOL .
+                'stat - get php facts statistics' . PHP_EOL .
+                'list - list all possible command';
     }
 }

--- a/commands/PhpFact/Implementations/Commands/ListCommand.php
+++ b/commands/PhpFact/Implementations/Commands/ListCommand.php
@@ -2,9 +2,9 @@
 
 namespace SoerBot\Commands\PhpFact\Implementations\Commands;
 
-use SoerBot\Commands\PhpFact\Abstractions\AbstractCommand;
+use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithoutArguments;
 
-class ListCommand extends AbstractCommand
+class ListCommand extends AbstractCommandWithoutArguments
 {
     /**
      * Returns command result.

--- a/commands/PhpFact/Implementations/Commands/SearchCommand.php
+++ b/commands/PhpFact/Implementations/Commands/SearchCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SoerBot\Commands\PhpFact\Implementations\Commands;
+
+use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
+use SoerBot\Commands\PhpFact\Exceptions\PhpFactException;
+use SoerBot\Commands\PhpFact\Exceptions\CommandWrongUsageException;
+use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithArguments;
+
+class SearchCommand extends AbstractCommandWithArguments
+{
+    /**
+     * Minimum pattern length.
+     */
+    public const MIN_LENGTH = 3;
+    /**
+     * Maximum pattern length.
+     */
+    public const MAX_LENGTH = 32;
+
+    /**
+     * @var string
+     */
+    private $pattern;
+
+    /**
+     * @var array
+     */
+    private $found = [];
+
+    /**
+     * SearchCommand constructor.
+     *
+     * @param PhpFacts $facts
+     * @param array $args
+     * @throws CommandWrongUsageException|PhpFactException
+     */
+    public function __construct(PhpFacts $facts, array $args)
+    {
+        parent::__construct($facts, $args);
+
+        $this->initPattern();
+        $this->search();
+    }
+
+    /**
+     * Returns command result.
+     *
+     * @return string
+     */
+    public function response(): string
+    {
+        return implode(PHP_EOL, $this->found);
+    }
+
+    /**
+     * Checks if pattern is valid.
+     *
+     * @throws CommandWrongUsageException
+     * @return void
+     */
+    protected function initPattern(): void
+    {
+        if (!isset($this->args['argument'])) {
+            throw new CommandWrongUsageException('Wrong usage of search command. Check if you pass argument.');
+        }
+
+        $this->args['argument'] = trim($this->args['argument']);
+
+        if (empty($this->args['argument'])) {
+            throw new CommandWrongUsageException('Wrong usage of search command. Check if argument is empty.');
+        }
+
+        $length = mb_strlen($this->args['argument']);
+
+        if ($length < self::MIN_LENGTH) {
+            throw new CommandWrongUsageException('Wrong usage of search command. Argument is less than minimum ' . self::MIN_LENGTH . ' chars.');
+        }
+
+        if ($length > self::MAX_LENGTH) {
+            throw new CommandWrongUsageException('Wrong usage of search command. Argument is more than maximum ' . self::MAX_LENGTH . ' chars.');
+        }
+
+        $this->pattern = $this->args['argument'];
+    }
+
+    /**
+     * Search pattern in PhpFacts.
+     *
+     * @throws PhpFactException
+     * @return void
+     */
+    protected function search(): void
+    {
+        $this->found = $this->facts->search($this->pattern);
+    }
+}

--- a/commands/PhpFact/Implementations/Commands/SearchCommand.php
+++ b/commands/PhpFact/Implementations/Commands/SearchCommand.php
@@ -50,7 +50,24 @@ class SearchCommand extends AbstractCommandWithArguments
      */
     public function response(): string
     {
-        return implode(PHP_EOL, $this->found);
+        if (empty($this->found)) {
+            return 'Nothing found on ' . $this->pattern . ' request';
+        }
+
+        $response = '';
+
+        if (($count = count($this->found)) > 1) {
+            foreach ($this->found as $k => $v) {
+                $response .= ($k + 1) . '. ' . $v;
+                if (--$count) {
+                    $response .= PHP_EOL;
+                }
+            }
+        } else {
+            $response = $this->found[0];
+        }
+
+        return $response;
     }
 
     /**

--- a/commands/PhpFact/Implementations/Commands/StatCommand.php
+++ b/commands/PhpFact/Implementations/Commands/StatCommand.php
@@ -2,9 +2,9 @@
 
 namespace SoerBot\Commands\PhpFact\Implementations\Commands;
 
-use SoerBot\Commands\PhpFact\Abstractions\AbstractCommand;
+use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithoutArguments;
 
-class StatCommand extends AbstractCommand
+class StatCommand extends AbstractCommandWithoutArguments
 {
     /**
      * Returns command result.

--- a/commands/PhpFact/Implementations/PhpFacts.php
+++ b/commands/PhpFact/Implementations/PhpFacts.php
@@ -8,6 +8,15 @@ use SoerBot\Commands\PhpFact\Abstractions\StorageInterface;
 class PhpFacts
 {
     /**
+     * Minimum pattern length.
+     */
+    public const SEARCH_MIN_LENGTH = 3;
+    /**
+     * Maximum pattern length.
+     */
+    public const SEARCH_MAX_LENGTH = 32;
+
+    /**
      * @var array
      */
     private $facts = [];
@@ -52,6 +61,41 @@ class PhpFacts
         $length = count($this->facts) - 1;
 
         return $this->facts[rand(0, $length)];
+    }
+
+    /**
+     * Search PHP facts by pattern.
+     *
+     * @param string $pattern
+     * @throws PhpFactException
+     * @return array
+     */
+    public function search(string $pattern): array
+    {
+        $pattern = trim($pattern);
+        $length = mb_strlen($pattern);
+
+        if ($length === 0) {
+            throw new PhpFactException('Passed patter is empty.');
+        }
+
+        if ($length < self::SEARCH_MIN_LENGTH) {
+            throw new PhpFactException('Passed pattern is less than minimum ' . self::SEARCH_MIN_LENGTH . ' chars.');
+        }
+
+        if ($length > self::SEARCH_MAX_LENGTH) {
+            throw new PhpFactException('Passed pattern is more than maximum ' . self::SEARCH_MAX_LENGTH . ' chars.');
+        }
+
+        $found = [];
+
+        foreach ($this->facts as $fact) {
+            if (mb_stripos($fact, $pattern) !== false) {
+                $found[] = $fact;
+            }
+        }
+
+        return $found;
     }
 
     /**

--- a/tests/Commands/PhpFact/AbstractCommandTest.php
+++ b/tests/Commands/PhpFact/AbstractCommandTest.php
@@ -4,7 +4,9 @@ namespace Tests\Commands\PhpFact\Commands;
 
 use Tests\TestCase;
 use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
-use SoerBot\Commands\PhpFact\Abstractions\AbstractCommand;
+use SoerBot\Commands\PhpFact\Abstractions\CommandInterface;
+use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithArguments;
+use SoerBot\Commands\PhpFact\Abstractions\AbstractCommandWithoutArguments;
 
 class AbstractCommandTest extends TestCase
 {
@@ -19,16 +21,29 @@ class AbstractCommandTest extends TestCase
     /**
      * Functionality.
      */
-    public function testConstructorMakeRightObject()
+    public function testConstructorMakeObjectWithoutArguments()
     {
         $facts = $this->createMock(PhpFacts::class);
-        $command = new class($facts) extends AbstractCommand {
+        $command = new class($facts) extends AbstractCommandWithoutArguments {
             public function response(): string
             {
                 return '';
             }
         };
 
-        $this->assertInstanceOf(AbstractCommand::class, $command);
+        $this->assertInstanceOf(CommandInterface::class, $command);
+    }
+
+    public function testConstructorMakeObjectWithArguments()
+    {
+        $facts = $this->createMock(PhpFacts::class);
+        $command = new class($facts, []) extends AbstractCommandWithArguments {
+            public function response(): string
+            {
+                return '';
+            }
+        };
+
+        $this->assertInstanceOf(CommandInterface::class, $command);
     }
 }

--- a/tests/Commands/PhpFact/CommandFactoryTest.php
+++ b/tests/Commands/PhpFact/CommandFactoryTest.php
@@ -11,6 +11,7 @@ use SoerBot\Commands\PhpFact\Exceptions\CommandNotFoundException;
 use SoerBot\Commands\PhpFact\Implementations\Commands\FactCommand;
 use SoerBot\Commands\PhpFact\Implementations\Commands\ListCommand;
 use SoerBot\Commands\PhpFact\Implementations\Commands\StatCommand;
+use SoerBot\Commands\PhpFact\Implementations\Commands\SearchCommand;
 
 class CommandFactoryTest extends TestCase
 {
@@ -72,6 +73,13 @@ class CommandFactoryTest extends TestCase
         $command = CommandFactory::build($this->facts, 'fact 22');
 
         $this->assertInstanceOf(FactCommand::class, $command);
+    }
+
+    public function testBuildMakeRightObjectWhenSearchCommandWithNumberArgument()
+    {
+        $command = CommandFactory::build($this->facts, 'search not_exist');
+
+        $this->assertInstanceOf(SearchCommand::class, $command);
     }
 
     public function testBuildMakeRightObjectWhenStatCommand()

--- a/tests/Commands/PhpFact/CommandFactoryTest.php
+++ b/tests/Commands/PhpFact/CommandFactoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Commands\PhpFact;
 use PHPUnit\Framework\TestCase;
 use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
 use SoerBot\Commands\PhpFact\Implementations\FileStorage;
+use SoerBot\Commands\PhpFact\Abstractions\CommandInterface;
 use SoerBot\Commands\PhpFact\Implementations\CommandFactory;
 use SoerBot\Commands\PhpFact\Exceptions\CommandNotFoundException;
 use SoerBot\Commands\PhpFact\Implementations\Commands\FactCommand;
@@ -52,6 +53,13 @@ class CommandFactoryTest extends TestCase
     /**
      * Functionality.
      */
+    public function testBuildMakeObjectWhichImplementsRightInterface()
+    {
+        $command = CommandFactory::build($this->facts, 'list');
+
+        $this->assertInstanceOf(CommandInterface::class, $command);
+    }
+
     public function testBuildMakeRightObjectWhenFactCommand()
     {
         $command = CommandFactory::build($this->facts, 'fact');

--- a/tests/Commands/PhpFact/Commands/FactCommandTest.php
+++ b/tests/Commands/PhpFact/Commands/FactCommandTest.php
@@ -83,14 +83,14 @@ class FactCommandTest extends TestCase
      */
     public function testResponseWithoutArgumentsReturnExpected()
     {
-        $command = new FactCommand($this->facts);
+        $command = new FactCommand($this->facts, []);
 
         $this->assertIsString($command->response());
     }
 
     public function testResponseWithoutArgumentsReturnExpectedSting()
     {
-        $command = new FactCommand($this->facts);
+        $command = new FactCommand($this->facts, []);
 
         $content = $this->getPrivateVariableValue($this->facts, 'facts');
 
@@ -124,7 +124,7 @@ class FactCommandTest extends TestCase
 
     public function testValidPositionIsEmptyWhenPositionArgumentNotExist()
     {
-        $command = new FactCommand($this->facts);
+        $command = new FactCommand($this->facts, []);
 
         $this->assertEmpty($this->getPrivateVariableValue($command, 'position'));
     }

--- a/tests/Commands/PhpFact/Commands/FactCommandTest.php
+++ b/tests/Commands/PhpFact/Commands/FactCommandTest.php
@@ -34,7 +34,7 @@ class FactCommandTest extends TestCase
 
         $this->expectException(CommandWrongUsageException::class);
 
-        new FactCommand($facts, ['position' => 'fail']);
+        new FactCommand($facts, ['argument' => 'fail']);
     }
 
     /**
@@ -43,7 +43,7 @@ class FactCommandTest extends TestCase
     public function testResponseWithArgumentsWhenPositionIsZero()
     {
         $position = 0;
-        $command = new FactCommand($this->facts, ['position' => $position]);
+        $command = new FactCommand($this->facts, ['argument' => $position]);
         $expected = 'The ' . $position . ' is wrong fact. Use $phpfact stat to find right position number.';
 
         $this->assertEquals($expected, $command->response());
@@ -52,7 +52,7 @@ class FactCommandTest extends TestCase
     public function testResponseWithArgumentsWhenPositionIsOne()
     {
         $position = 1;
-        $command = new FactCommand($this->facts, ['position' => $position]);
+        $command = new FactCommand($this->facts, ['argument' => $position]);
 
         $content = $this->getPrivateVariableValue($this->facts, 'facts');
 
@@ -62,7 +62,7 @@ class FactCommandTest extends TestCase
     public function testResponseWithArgumentsWhenPositionIsFive()
     {
         $position = 5;
-        $command = new FactCommand($this->facts, ['position' => $position]);
+        $command = new FactCommand($this->facts, ['argument' => $position]);
 
         $content = $this->getPrivateVariableValue($this->facts, 'facts');
 
@@ -72,7 +72,7 @@ class FactCommandTest extends TestCase
     public function testResponseWithArgumentsWhenPositionIsSix()
     {
         $position = 6;
-        $command = new FactCommand($this->facts, ['position' => $position]);
+        $command = new FactCommand($this->facts, ['argument' => $position]);
         $expected = 'The ' . $position . ' is wrong fact. Use $phpfact stat to find right position number.';
 
         $this->assertEquals($expected, $command->response());
@@ -99,14 +99,14 @@ class FactCommandTest extends TestCase
 
     public function testResponseWithArgumentsReturnExpected()
     {
-        $command = new FactCommand($this->facts, ['position' => 1]);
+        $command = new FactCommand($this->facts, ['argument' => 1]);
 
         $this->assertIsString($command->response());
     }
 
     public function testResponseWithArgumentsReturnExpectedStringWhenFactExist()
     {
-        $command = new FactCommand($this->facts, ['position' => 2]);
+        $command = new FactCommand($this->facts, ['argument' => 2]);
 
         $content = $this->getPrivateVariableValue($this->facts, 'facts');
 
@@ -116,7 +116,7 @@ class FactCommandTest extends TestCase
     public function testResponseWithArgumentsReturnExpectedStringWhenFactNotExist()
     {
         $position = 100;
-        $command = new FactCommand($this->facts, ['position' => $position]);
+        $command = new FactCommand($this->facts, ['argument' => $position]);
         $expected = 'The ' . $position . ' is wrong fact. Use $phpfact stat to find right position number.';
 
         $this->assertEquals($expected, $command->response());
@@ -131,7 +131,7 @@ class FactCommandTest extends TestCase
 
     public function testValidPositionIsSetWhenPositionArgumentExist()
     {
-        $command = new FactCommand($this->facts, ['position' => 22]);
+        $command = new FactCommand($this->facts, ['argument' => 22]);
 
         $this->assertEquals(22, $this->getPrivateVariableValue($command, 'position'));
     }

--- a/tests/Commands/PhpFact/Commands/SearchCommandTest.php
+++ b/tests/Commands/PhpFact/Commands/SearchCommandTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Commands\PhpFact\Commands;
+
+use Tests\TestCase;
+use SoerBot\Commands\PhpFact\Implementations\PhpFacts;
+use SoerBot\Commands\PhpFact\Implementations\FileStorage;
+use SoerBot\Commands\PhpFact\Exceptions\CommandWrongUsageException;
+use SoerBot\Commands\PhpFact\Implementations\Commands\SearchCommand;
+
+class SearchCommandTest extends TestCase
+{
+    private $facts;
+
+    public function setUp()
+    {
+        try {
+            $file = __DIR__ . '/../phpfacts.txt';
+            $storage = new FileStorage($file);
+            $this->facts = new PhpFacts($storage);
+        } catch (\Throwable $e) {
+            $this->fail('Exception with ' . $e->getMessage() . ' was thrown is setUp method!');
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * Exceptions.
+     */
+    public function testConstructorThrowExceptionWhenArgumentNotSet()
+    {
+        $facts = $this->createMock(PhpFacts::class);
+
+        $this->expectException(CommandWrongUsageException::class);
+        $this->expectExceptionMessage('Wrong usage of search command. Check if you pass argument.');
+
+        new SearchCommand($facts, []);
+    }
+
+    public function testConstructorThrowExceptionWhenPatternArgumentNotString()
+    {
+        $facts = $this->createMock(PhpFacts::class);
+
+        $this->expectException(CommandWrongUsageException::class);
+        $this->expectExceptionMessage('Wrong usage of search command. Check if argument is empty.');
+
+        new SearchCommand($facts, ['argument' => '    ']);
+    }
+
+    public function testConstructorThrowExceptionWhenPatternIsLessThanMinLength()
+    {
+        $facts = $this->createMock(PhpFacts::class);
+
+        $this->expectException(CommandWrongUsageException::class);
+        $this->expectExceptionMessage('Wrong usage of search command. Argument is less than minimum ' . SearchCommand::MIN_LENGTH . ' chars.');
+
+        new SearchCommand($facts, ['argument' => str_repeat('t', SearchCommand::MIN_LENGTH - 1)]);
+    }
+
+    public function testConstructorThrowExceptionWhenPatternIsMoreThanMaxLength()
+    {
+        $facts = $this->createMock(PhpFacts::class);
+
+        $this->expectException(CommandWrongUsageException::class);
+        $this->expectExceptionMessage('Wrong usage of search command. Argument is more than maximum ' . SearchCommand::MAX_LENGTH . ' chars.');
+
+        new SearchCommand($facts, ['argument' => str_repeat('t', SearchCommand::MAX_LENGTH + 1)]);
+    }
+
+    /**
+     * Corner cases.
+     */
+    public function testConstructorDontThrowExceptionWhenPatternIsMin()
+    {
+        $facts = $this->createMock(PhpFacts::class);
+
+        try {
+            new SearchCommand($facts, ['argument' => str_repeat('t', SearchCommand::MIN_LENGTH)]);
+        } catch (CommandWrongUsageException $e) {
+            $this->fail('Exception thrown on min plus one with message ' . $e->getMessage() . '');
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function testConstructorDontThrowExceptionWhenPatternIsMax()
+    {
+        $facts = $this->createMock(PhpFacts::class);
+
+        try {
+            new SearchCommand($facts, ['argument' => str_repeat('t', SearchCommand::MAX_LENGTH)]);
+        } catch (CommandWrongUsageException $e) {
+            $this->fail('Exception thrown on min plus one with message ' . $e->getMessage() . '');
+        }
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Functionality.
+     */
+    public function testResponseWithArgumentsReturnString()
+    {
+        $command = new SearchCommand($this->facts, ['argument' => 'test']);
+
+        $this->assertIsString($command->response());
+    }
+
+    public function testResponseWithArgumentsSetPatternWithoutSpace()
+    {
+        $expected = 'string';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $content = $this->getPrivateVariableValue($command, 'pattern');
+
+        $this->assertEquals($expected, $content);
+    }
+
+    public function testResponseWithArgumentsSetPatternWithSpace()
+    {
+        $expected = 'some string';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $content = $this->getPrivateVariableValue($command, 'pattern');
+
+        $this->assertEquals($expected, $content);
+    }
+
+    public function testSearchFindNothingWhenNotExistPattern()
+    {
+        $expected = 'not_exist';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $found = $this->getPrivateVariableValue($command, 'found');
+
+        $this->assertEmpty($found);
+    }
+
+    public function testSearchFindOneWhenOneExistPattern()
+    {
+        $expected = 'yield';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $found = $this->getPrivateVariableValue($command, 'found');
+
+        $this->assertNotEmpty($found);
+        $this->assertCount(1, $found);
+    }
+
+    public function testSearchFindTwoWhenTwoExistPattern()
+    {
+        $expected = 'java';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $found = $this->getPrivateVariableValue($command, 'found');
+
+        $this->assertNotEmpty($found);
+        $this->assertCount(2, $found);
+    }
+
+    public function testResponseReturnExpectedOneWhenOneExistPattern()
+    {
+        $expected = 'yield';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $found = $this->facts->search($expected);
+
+        $this->assertEquals($command->response(), $found[0]);
+    }
+
+    public function testResponseReturnExpectedTwoWhenTwoExistPattern()
+    {
+        $expected = 'java';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $found = $this->facts->search($expected);
+
+        $this->assertEquals($command->response(), $found[0] . PHP_EOL . $found[1]);
+    }
+}

--- a/tests/Commands/PhpFact/Commands/SearchCommandTest.php
+++ b/tests/Commands/PhpFact/Commands/SearchCommandTest.php
@@ -159,6 +159,14 @@ class SearchCommandTest extends TestCase
         $this->assertCount(2, $found);
     }
 
+    public function testResponseReturnExpectedOneWhenNotExistPattern()
+    {
+        $expected = 'not_exist';
+        $command = new SearchCommand($this->facts, ['argument' => $expected]);
+
+        $this->assertEquals('Nothing found on ' . $expected . ' request', $command->response());
+    }
+
     public function testResponseReturnExpectedOneWhenOneExistPattern()
     {
         $expected = 'yield';
@@ -176,6 +184,6 @@ class SearchCommandTest extends TestCase
 
         $found = $this->facts->search($expected);
 
-        $this->assertEquals($command->response(), $found[0] . PHP_EOL . $found[1]);
+        $this->assertEquals($command->response(), '1. ' . $found[0] . PHP_EOL . '2. ' . $found[1]);
     }
 }

--- a/tests/Commands/PhpFact/PhpFactCommandTest.php
+++ b/tests/Commands/PhpFact/PhpFactCommandTest.php
@@ -117,7 +117,7 @@ class PhpFactCommandTest extends TestCase
         $this->command->run($commandMessage, new ArrayObject(['command' => 'fact']), false);
     }
 
-    public function testRunSayConcreteFactWhenFactCommandExistingNumber()
+    public function testRunSayConcreteFactWhenFactCommandExistNumber()
     {
         try {
             $storage = new FileStorage();
@@ -164,6 +164,55 @@ class PhpFactCommandTest extends TestCase
             );
 
         $this->command->run($commandMessage, new ArrayObject(['command' => 'fact 100']), false);
+    }
+
+    public function testRunSaySearchFactWhenSearchCommandExistPattern()
+    {
+        try {
+            $storage = new FileStorage();
+            $factObject = new PhpFacts($storage);
+        } catch (\Throwable $e) {
+            $this->fail('Exception with ' . $e->getMessage() . ' was thrown is test method!');
+        }
+
+        $facts = $this->getPrivateVariableValue($factObject, 'facts');
+
+        $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
+        $commandMessage->expects($this->once())
+            ->method('say')
+            ->with(
+                $facts[4]
+            );
+
+        $this->command->run($commandMessage, new ArrayObject(['command' => 'search yield']), false);
+    }
+
+    public function testRunSaySearchFactWhenSearchCommandNotExistPattern()
+    {
+        try {
+            $storage = new FileStorage();
+            $factObject = new PhpFacts($storage);
+        } catch (\Throwable $e) {
+            $this->fail('Exception with ' . $e->getMessage() . ' was thrown is test method!');
+        }
+
+        $facts = $this->getPrivateVariableValue($factObject, 'facts');
+
+        $commandMessage = $this->createMock('CharlotteDunois\Livia\CommandMessage');
+        $commandMessage->expects($this->once())
+            ->method('say')
+            ->with(
+                $this->logicalAnd(
+                    $this->isType('string'),
+                    $this->callback(
+                        function ($parameter) use ($facts) {
+                            return !in_array($parameter, $facts);
+                        }
+                    )
+                )
+            );
+
+        $this->command->run($commandMessage, new ArrayObject(['command' => 'search not_exist']), false);
     }
 
     public function testRunSayOneOfFactWhenCountCommand()


### PR DESCRIPTION
Зарефакторил и обновил команду PhpFact. Выделил интерфейс, от которого наследуются два абстрактных класса (команда без аргументов, команда с аргументами), от которых наследуются уже все остальные команды. Так же добавил большей гибкости в Фабричном методе, за счет переработки регулярного выражения на более универсальный вариант.

Добавил команду search, которая позволяет находить информацию о фактах по переданному слову или тексту. Если находится несколько фактов, то выводимые факты нумеруются.

